### PR TITLE
feat: 0.0.2 RingaBuf is an opaque pointer

### DIFF
--- a/demo/main.c
+++ b/demo/main.c
@@ -28,36 +28,38 @@ int main(void) {
     printf("Hello, world!\n");
     printf("Using ringabuf v%s\n", string_ringabuf_version());
     char myBuf[BUFSIZE] = {0};
-    RingaBuf rb = rb_new_arr(myBuf, char, BUFSIZE);
+    RingaBuf rb = NULL;
+    rb = malloc(rb_structsize__());
+    rb = rb_new_arr(rb, myBuf, char, BUFSIZE);
 
-    printf("head: %u, tail: %u\n", rb.head, rb.tail);
-    bool res = rb_push_bytes(&rb, "Hiiiii", strlen("Hiiiiii"));
+    printf("head: %u, tail: %u\n", rb->head, rb->tail);
+    bool res = rb_push_bytes(rb, "Hiiiii", strlen("Hiiiiii"));
 
-    printf("head: %u, tail: %u\n", rb.head, rb.tail);
+    printf("head: %u, tail: %u\n", rb->head, rb->tail);
     printf("res: %s\n", (res ? "true" : "false"));
 
     char msg[50] = {0};
-    size_t res_2 = rb_pop_bytes(&rb, msg, 7);
+    size_t res_2 = rb_pop_bytes(rb, msg, 7);
     printf("res_2: %zu\n", res_2);
-    printf("head: %u, tail: %u\n", rb.head, rb.tail);
+    printf("head: %u, tail: %u\n", rb->head, rb->tail);
     printf("msg: %s\n", msg);
 
     Example ex = (Example) { .foo = 42, };
 
-    bool res_3 = rb_push(&rb, ex);
+    bool res_3 = rb_push(rb, ex);
     printf("res_3: %s\n", (res_3 ? "true" : "false"));
-    printf("head: %u, tail: %u\n", rb.head, rb.tail);
+    printf("head: %u, tail: %u\n", rb->head, rb->tail);
 
     Example ex_2 = {0};
 
-    size_t res_4 = rb_pop(&rb, ex_2);
+    size_t res_4 = rb_pop(rb, ex_2);
     printf("res_4: %zu\n", res_4);
-    printf("head: %u, tail: %u\n", rb.head, rb.tail);
+    printf("head: %u, tail: %u\n", rb->head, rb->tail);
     printf("ex_2.foo = {%i}\n", ex_2.foo);
 
-    try_rb_push(&rb, ex);
+    try_rb_push(rb, ex);
     ex_2 = (Example){0};
-    try_rb_pop(&rb, ex_2);
+    try_rb_pop(rb, ex_2);
     printf("ex_2.foo = {%i}\n", ex_2.foo);
 
     return 0;

--- a/src/ringabuf.h
+++ b/src/ringabuf.h
@@ -63,6 +63,8 @@ RingaBuf rb_new_(RingaBuf rb, char* data, size_t size, int count);
 int32_t rb_get_head(RingaBuf rb);
 int32_t rb_get_tail(RingaBuf rb);
 size_t rb_get_capacity(RingaBuf rb);
+bool rb_isfull(RingaBuf rb);
+char* rb_get_data(RingaBuf rb);
 
 bool rb_push_byte(RingaBuf rb, char* data);
 size_t rb_push_bytes(RingaBuf rb, char* bytes, size_t count);
@@ -149,9 +151,27 @@ size_t rb_get_capacity(RingaBuf rb)
 {
     if (rb == NULL) {
         fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
-        return -1;
+        return 0;
     }
     return rb->capacity;
+}
+
+bool rb_isfull(RingaBuf rb)
+{
+    if (rb == NULL) {
+        fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
+        return false;
+    }
+    return rb->is_full;
+}
+
+char* rb_get_data(RingaBuf rb)
+{
+    if (rb == NULL) {
+        fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
+        return NULL;
+    }
+    return rb->data;
 }
 
 bool rb_push_byte(RingaBuf rb, char* data)

--- a/src/ringabuf.h
+++ b/src/ringabuf.h
@@ -52,7 +52,7 @@ int int_ringabuf_version(void);
 
 typedef struct RingaBuf_s *RingaBuf;
 
-size_t rb_structsize(void);
+size_t rb_structsize__(void);
 size_t rb_structalign__(void);
 
 RingaBuf rb_new_(RingaBuf rb, char* data, size_t size, int count);

--- a/src/ringabuf.h
+++ b/src/ringabuf.h
@@ -26,7 +26,7 @@
 
 #define RINGABUF_MAJOR 0 /**< Represents current major release.*/
 #define RINGABUF_MINOR 0 /**< Represents current minor release.*/
-#define RINGABUF_PATCH 1 /**< Represents current patch release.*/
+#define RINGABUF_PATCH 2 /**< Represents current patch release.*/
 
 /**
  * Defines current API version number from RINGABUF_MAJOR, RINGABUF_MINOR and RINGABUF_PATCH.
@@ -38,7 +38,7 @@ static const int RINGABUF_API_VERSION_INT =
 /**
  * Defines current API version string.
  */
-static const char RINGABUF_API_VERSION_STRING[] = "0.0.1"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
+static const char RINGABUF_API_VERSION_STRING[] = "0.0.2"; /**< Represents current version with MAJOR.MINOR.PATCH format.*/
 
 /**
  * Returns current ringabuf version as a string.

--- a/src/ringabuf.h
+++ b/src/ringabuf.h
@@ -60,6 +60,10 @@ RingaBuf rb_new_(RingaBuf rb, char* data, size_t size, int count);
 #define rb_new_arr(rb, data, type, count) rb_new_((rb), (data), sizeof(type), (count))
 #define rb_new(rb, data, type) rb_new_((rb), (data), sizeof(type), 1)
 
+int32_t rb_get_head(RingaBuf rb);
+int32_t rb_get_tail(RingaBuf rb);
+size_t rb_get_capacity(RingaBuf rb);
+
 bool rb_push_byte(RingaBuf rb, char* data);
 size_t rb_push_bytes(RingaBuf rb, char* bytes, size_t count);
 
@@ -121,6 +125,33 @@ RingaBuf rb_new_(RingaBuf rb, char* data, size_t size, int count)
     rb->capacity = count * size,
     rb->is_full = false;
     return rb;
+}
+
+int32_t rb_get_head(RingaBuf rb)
+{
+    if (rb == NULL) {
+        fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
+        return -1;
+    }
+    return rb->head;
+}
+
+int32_t rb_get_tail(RingaBuf rb)
+{
+    if (rb == NULL) {
+        fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
+        return -1;
+    }
+    return rb->tail;
+}
+
+size_t rb_get_capacity(RingaBuf rb)
+{
+    if (rb == NULL) {
+        fprintf(stderr, "%s():    Passed RingaBuf was NULL.\n", __func__);
+        return -1;
+    }
+    return rb->capacity;
 }
 
 bool rb_push_byte(RingaBuf rb, char* data)


### PR DESCRIPTION
- Adds `rn_structsize__()` and `rb_structalign__()` to allow allocation for the structure from custom allocators
- Refactors `RingaBuf` to be an opaque pointer
- Adds getters to current properties, with `NULL` pointer checking
- Refactor `rb_new()` to only prepare the passed `RingaBuf`, which should not be `NULL` before calling it
  - Requires allocation for the ring to be performed before this call